### PR TITLE
Update to Beersmith 2.3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:12.04
+FROM ubuntu:16.04
 
-ADD https://s3.amazonaws.com/BeerSmith2-2/BeerSmith-2.2.12_amd64.deb /tmp/
+ADD https://s3.amazonaws.com/beersmith2-3/BeerSmith-2.3.12_amd64.deb /tmp/
 RUN apt-get update && \
-  apt-get -y install libgtk2.0-bin libwebkitgtk-1.0-0 alsa-utils alsa-base cups-client && \
-  dpkg -i /tmp/BeerSmith-2.2.12_amd64.deb && \
+  apt-get install -y /tmp/BeerSmith-2.3.12_amd64.deb && \
+  apt-get clean && \
   mkdir -p /home/beersmith2/.beersmith2 && \
   chmod 777 -R /home/beersmith2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
-FROM debian:latest
+FROM ubuntu:12.04
 
-RUN apt-get update
 ADD https://s3.amazonaws.com/BeerSmith2-2/BeerSmith-2.2.12_amd64.deb /tmp/
-RUN dpkg -i /tmp/BeerSmith-2.2.12_amd64.deb; exit 0
-RUN apt-get -y install -f
-RUN apt-get -y install cups-client
-
-RUN mkdir -p /home/beersmith2/.beersmith2 && \
-    chmod 777 -R /home/beersmith2
+RUN apt-get update && \
+  apt-get -y install libgtk2.0-bin libwebkitgtk-1.0-0 alsa-utils alsa-base cups-client && \
+  dpkg -i /tmp/BeerSmith-2.2.12_amd64.deb && \
+  mkdir -p /home/beersmith2/.beersmith2 && \
+  chmod 777 -R /home/beersmith2
 
 ENV HOME /home/beersmith2
 CMD /usr/bin/beersmith2

--- a/beersmith2.sh
+++ b/beersmith2.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+mkdir $HOME/.beersmith2
 docker run -ti --rm -e DISPLAY=$DISPLAY -u $UID:`id -g $USER` \
     -v $HOME/.beersmith2:/home/beersmith2/.beersmith2 \
     -v $HOME/Documents:/home/beersmith2/Documents \


### PR DESCRIPTION
This updates the container to Beersmith 2.3.12, and Ubuntu 16.04.

I've also simplified how dependencies are installed, by delegating the heavy-lifting to `apt`.

The resulting image should be lighter, due to the grouping of commands into a single one that includes `apt-get clean`, but both updates appear to have introduced more dependencies, increasing the image size by 31 MB (238 MB).

Included is a call to `mkdir` to avoid letting `docker run` create the `.beersmith2` directory with root ownership.